### PR TITLE
Windows Setup Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,19 @@ Openplace (styled lowercase) is a free unofficial open source backend for [wplac
 > [!WARNING]
 > This is a work-in-progress. Expect unfinished features and bugs. Please help us by posting issues in #help-n-support on our [Discord server](https://discord.gg/ZRC4DnP9Z2) or by contributing pull requests. Thanks!
 
-## macOS
-### Getting Started
-This is where you will be preparing your machine to run openplace.
-1. install brew, node and git
-2. run `git clone --recurse-submodules https://github.com/openplaceteam/openplace`
-3. cd into the openplace directory
-4. run ``npm i && brew install mariadb caddy nss``
-5. brew will then spit out a command to inform you on how to start it. if it doesn't, run `brew services start mariadb && brew services start caddy`
-#### Configuring and building the database
-1. run `sudo mysql_secure_installation`
-2. it will then ask you for your current root password. just hit enter
-3. hit 'n' when it asks you to switch to unix_socket authentication
-4. hit 'y' when it asks you to change your root password. for demonstration purposes, i have made my password 'password'. (do not do this)
-5. when it asks you to remove anonymous users, hit 'y'
-6. it will ask you if you want to disallow remote root logins, this is entirely up to you.
-7. hit 'y' when it asks you to remove the test database
-8. finally, hit 'y' when it asks you to reload configuration.
-9. copy the .env.example file on the root directory and rename it to .env where `root:password` is, replace `password` with your password.
-10. you can now run `npx prisma migrate deploy`
-11. next, `npx prisma generate`
-12. NEXT, `npx prisma db push`
-13. then you can run `npm run dev`
-14. in another terminal, cd to the same root directory and run `caddy run --config Caddyfile`
+## Getting Started
 
-#### Spinning up your server
+### Windows
+
+- [Guideline for Windows Installation](SETUP_WINDOWS.md)
+
+### macOS
+
+- [Guideline for macOS Installation](SETUP_MACOS.md)
+
+
+### Server accessibility
 You will be required to configure an SSL certificate if you plan to use this in production. However, if you are only using this with you and your friends, you can simply navigate to `https://{IP}:8080` NOTE: openplace is only hosted over HTTPS. you will run into HTTP error 400 if you attempt to load the website over HTTP.
 
-#### Updating your database
+### Updating your database
 In the event that the database schematic changes, you simply need to run `npm run db:push` to update your database schema.

--- a/RestartNSSMDaemons_AS_ADMIN.cmd
+++ b/RestartNSSMDaemons_AS_ADMIN.cmd
@@ -1,0 +1,2 @@
+call StopNSSMDaemons.cmd
+call StartNSSMDaemons.cmd

--- a/SETUP_MACOS.md
+++ b/SETUP_MACOS.md
@@ -1,0 +1,99 @@
+# Getting Started with OpenPlace (macOS)
+
+This guide will help you prepare a **macOS** machine to run **OpenPlace**.
+
+---
+
+## Step 1: Install Prerequisites
+Make sure you have the following installed on your system:
+- **Homebrew**
+- **Node.js**
+- **Git**
+
+---
+
+## Step 2: Clone the Repository
+```bash
+git clone --recurse-submodules https://github.com/openplaceteam/openplace
+cd openplace
+```
+
+---
+
+## Step 3: Install Dependencies
+```bash
+npm i && brew install mariadb caddy nss
+```
+If brew does not automatically start the services, run:
+```bash
+brew services start mariadb
+brew services start caddy
+```
+
+---
+
+## Step 4: Configure and Build the Database
+
+Run the secure installation script for MySQL:
+```bash
+sudo mysql_secure_installation
+```
+
+Follow the prompts:
+1. Press **Enter** for the current root password.
+2. Enter **`n`** when asked to switch to unix_socket authentication.
+3. Enter **`y`** when asked to change your root password.  
+   ⚠️ Do **not** use "password" as shown in this demo.
+4. Enter **`y`** to remove anonymous users.
+5. Choose whether to disallow remote root logins (**recommended: y**).
+6. Enter **`y`** to remove the test database.
+7. Enter **`y`** to reload configuration.
+
+Next, configure the environment:
+```bash
+cp .env.example .env
+```
+Update the `.env` file with your chosen MySQL password.
+
+---
+
+## Step 5: Database Setup
+
+Run the following Prisma commands:
+```bash
+npx prisma migrate deploy
+npx prisma generate
+npx prisma db push
+```
+
+---
+
+## Step 6: Run the Application
+
+Start the dev server:
+```bash
+npm run dev
+```
+
+In another terminal, run Caddy:
+```bash
+caddy run --config Caddyfile
+```
+
+---
+
+## Notes on SSL
+OpenPlace **requires HTTPS**.  
+If you are testing locally, you can access the app at:
+```
+https://{IP}:8080
+```
+⚠️ Attempting to use HTTP will result in an **HTTP 400 error**.
+
+---
+
+## Updating the Database
+If the database schema changes, update it with:
+```bash
+npm run db:push
+```

--- a/SETUP_WINDOWS.md
+++ b/SETUP_WINDOWS.md
@@ -1,0 +1,122 @@
+# OpenPlace — Windows Setup Guide
+
+This guide will help you prepare a **Windows** machine to run **openplace**.
+
+---
+
+## 1. Install prerequisites
+
+You need **Node.js**, **Git**, **MariaDB**, **Caddy**.
+
+- Using **winget** (Windows 10/11 PowerShell as Administrator):
+
+```powershell
+winget install Git.Git
+winget install OpenJS.NodeJS.LTS
+winget install MariaDB.Server
+winget install CaddyServer.Caddy
+```
+
+- Using **Chocolatey** (cmd as Administrator):
+
+```cmd
+choco install git nodejs-lts mariadb caddy -y
+```
+
+---
+
+## 2. Clone the repository
+
+```powershell
+git clone --recurse-submodules https://github.com/openplaceteam/openplace
+cd openplace
+```
+
+---
+
+## 3. Install Node dependencies
+
+```powershell
+npm install
+```
+
+---
+
+## 4 Stop Caddy services (required if installed as service)
+
+- If Caddy was installed as services, stop it via **Services.msc**  
+- Or manually:
+
+```powershell
+net stop caddy
+```
+
+---
+
+## 5. Configure and build the database
+
+1. Copy `.env.example` to `.env`:
+
+```powershell
+Copy-Item .env.example .env
+```
+
+Edit `.env` and replace `root:password` with your MariaDB root password.
+
+> [!WARNING]
+> Escape special character listed in this table: [Percent-Encoding](https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding)
+
+---
+
+## 6. Setup Prisma and database
+
+```powershell
+npx prisma migrate deploy
+npx prisma generate
+npx prisma db push
+```
+
+---
+
+## 7. Run the development server
+
+```powershell
+npm run dev
+```
+
+---
+
+## 8. Run Caddy
+
+If not already running, start Caddy in another terminal:
+
+```powershell
+caddy run --config .\Caddyfile
+```
+
+---
+
+## Spinning up your server
+
+- For production, configure an SSL certificate.  
+- For local/private use, navigate to:
+
+```
+https://{your-local-IP}:8080
+```
+
+> [!WARNING]
+> ⚠️ **Important:** OpenPlace only works over HTTPS. If you try HTTP, you’ll get **400 Bad Request**.
+
+
+---
+
+## Updating your database
+
+If the schema changes, run:
+
+```powershell
+npm run db:push
+```
+
+---

--- a/SETUP_WINDOWS.md
+++ b/SETUP_WINDOWS.md
@@ -13,16 +13,20 @@ You need **Node.js**, **Git**, **MariaDB**, **Caddy**.
 ```powershell
 winget install Git.Git
 winget install OpenJS.NodeJS.LTS
-winget install MariaDB.Server
 winget install CaddyServer.Caddy
+winget install nssm
 ```
 
 - Using **Chocolatey** (cmd as Administrator):
 
 ```cmd
-choco install git nodejs-lts mariadb caddy -y
+choco install git nodejs-lts caddy nssm -y
 ```
 
+- Download MariaDB Server via this link: [MariaDB Server](https://mirror.mva-n.net/mariadb///mariadb-12.0.2/winx64-packages/mariadb-12.0.2-winx64.msi)
+- Run the Installer
+- Set a root password and keep everything default
+  
 ---
 
 ## 2. Clone the repository
@@ -61,7 +65,7 @@ net stop caddy
 Copy-Item .env.example .env
 ```
 
-Edit `.env` and replace `root:password` with your MariaDB root password.
+Edit `.env` and replace `root:password` with your MariaDB root password and change the `JWT_SECRET`.
 
 > [!WARNING]
 > Escape special character listed in this table: [Percent-Encoding](https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding)
@@ -78,21 +82,47 @@ npx prisma db push
 
 ---
 
-## 7. Run the development server
+## 7.A Run each server on its own
 
+run frontend in one terminal: 
 ```powershell
 npm run dev
+```
+run caddy in a second terminal:
+```powershell
+caddy run --config .\Caddyfile
 ```
 
 ---
 
-## 8. Run Caddy
+## 7.B Run both with one terminal
 
-If not already running, start Caddy in another terminal:
-
-```powershell
-caddy run --config .\Caddyfile
+```cmd
+npm run exec
 ```
+
+## 7.C Run both in background
+
+Install Daemons:
+```
+installNSSMDaemons_AS_ADMIN.cmd
+```
+
+Start Daemons:
+```
+StartNSSMDaemons_AS_ADMIN.cmd
+```
+
+Stop Daemons:
+```
+StopNSSMDaemons_AS_ADMIN.cmd
+```
+
+Restart Daemons:
+```
+RestartNSSMDaemons_AS_ADMIN.cmd
+```
+
 
 ---
 

--- a/StartNSSMDaemons_AS_ADMIN.cmd
+++ b/StartNSSMDaemons_AS_ADMIN.cmd
@@ -1,0 +1,2 @@
+net start Caddy
+net start FrontendApp

--- a/StopNSSMDaemons_AS_ADMIN.cmd
+++ b/StopNSSMDaemons_AS_ADMIN.cmd
@@ -1,0 +1,2 @@
+net stop Caddy
+net stop FrontendApp

--- a/installNSSMDaemons_AS_ADMIN.cmd
+++ b/installNSSMDaemons_AS_ADMIN.cmd
@@ -1,0 +1,2 @@
+nssm install Caddy "C:\Users\admin\AppData\Local\Microsoft\WinGet\Packages\CaddyServer.Caddy_Microsoft.Winget.Source_8wekyb3d8bbwe\caddy.exe" "run --config C:\Users\admin\openplace\Caddyfile"
+nssm install FrontendApp "C:\Program Files\nodejs\npm.cmd" "run dev"


### PR DESCRIPTION
- Added Windows Setup README
- Moved Setup instructions to own markdown files
- Added Service script to install caddy and frontend server as services to run in the background
