### PR TITLE
use BigInt instead of Int for large geonames, optimize SQL import

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -164,7 +164,7 @@ model Region {
   countryId  Int
   latitude   Float
   longitude  Float
-  population Int    @default(0)
+  population  BigInt    @default(0)
 
   @@unique([latitude, longitude])
   @@index([latitude])

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -7,8 +7,12 @@ import inquirer from "inquirer";
 import { COUNTRIES } from "../src/utils/country";
 import chalk from "chalk";
 
-const BATCH_SIZE = Number(process.env.REGION_BATCH_SIZE ?? 4000);  // lines per DB batch
-const CONCURRENCY = Number(process.env.REGION_CONCURRENCY ?? 32);  // concurrent upserts within a batch
+(BigInt.prototype as any).toJSON = function () {
+	return this.toString();
+};
+
+const BATCH_SIZE = Number(process.env.REGION_BATCH_SIZE ?? 10000);  // lines per DB batch
+const CONCURRENCY = Number(process.env.REGION_CONCURRENCY ?? 32);  // concurrent upserts within a batch (kept for backwards compatibility but unused in bulk insert)
 const PROGRESS_REFRESH_MS = Number(process.env.PROGRESS_REFRESH_MS ?? 120); // progress redraw throttle
 
 const prisma = new PrismaClient({
@@ -20,15 +24,15 @@ const yes = process.argv.includes("--yes");
 async function prompt(message: string, defaultValue = false) {
 	if (yes) return defaultValue;
 	return (
-    await inquirer.prompt([
-    	{
-    		type: "confirm",
-    		name: "answer",
-    		message,
-    		default: defaultValue
-    	}
-    ])
-  ).answer as boolean;
+		await inquirer.prompt([
+			{
+				type: "confirm",
+				name: "answer",
+				message,
+				default: defaultValue
+			}
+		])
+	).answer as boolean;
 }
 
 function makeProgressPrinter(prefix = "Downloading: ") {
@@ -75,9 +79,9 @@ async function downloadToUint8Array(url: string): Promise<Uint8Array[]> {
 
 function nowStr() {
 	return new Date()
-		.toISOString()
-		.replace("T", " ")
-		.replace("Z", "");
+	.toISOString()
+	.replace("T", " ")
+	.replace("Z", "");
 }
 
 function limit(concurrency: number) {
@@ -87,7 +91,7 @@ function limit(concurrency: number) {
 		running--;
 		if (queue.length > 0) queue.shift()!();
 	};
-	return async <T>(fn: () => Promise<T>): Promise<T> =>
+		return async <T>(fn: () => Promise<T>): Promise<T> =>
 		new Promise<T>((resolve, reject) => {
 			const run = async () => {
 				running++;
@@ -134,16 +138,16 @@ try {
 
 	await prisma.$transaction(
 		baseUsers.map((user) =>
-			prisma.user.upsert({
-				where: { id: user.id },
-				update: {},
-				create: {
-					...user,
-					country: "XX",
-					passwordHash: "",
-					banned: true
-				}
-			})
+		prisma.user.upsert({
+			where: { id: user.id },
+			update: {},
+			create: {
+				...user,
+				country: "XX",
+				passwordHash: "",
+				banned: true
+			}
+		})
 		)
 	);
 
@@ -152,17 +156,17 @@ try {
 	console.log(
 		chalk.gray(
 			hasRegionData
-				? "You already have region data. You can choose to update it:"
-				: "Choose the region data you would like to use:"
+			? "You already have region data. You can choose to update it:"
+			: "Choose the region data you would like to use:"
 		)
 	);
 
 	let regionSelection:
-		| null
-		| "cities500"
-		| "cities1000"
-		| "cities5000"
-		| "allCountries" = null;
+	| null
+	| "cities500"
+	| "cities1000"
+	| "cities5000"
+	| "allCountries" = null;
 
 	if (!yes) {
 		const regionChoice = await inquirer.prompt([
@@ -173,23 +177,23 @@ try {
 				choices: [
 					{
 						name: `Skip (${hasRegionData ? "keep existing data" : "don’t use region data"})`,
-						value: null
+												   value: null
 					},
 					{
 						name: "Cities with population > 500 (224,000+ entries, recommended)",
-						value: "cities500"
+												   value: "cities500"
 					},
 					{
 						name: "Cities with population > 1000 (162,000+ entries)",
-						value: "cities1000"
+												   value: "cities1000"
 					},
 					{
 						name: "Cities with population > 5000 (66,000+ entries)",
-						value: "cities5000"
+												   value: "cities5000"
 					},
 					{
 						name: "Pin-point landmarks (13 million+ entries, not recommended)",
-						value: "allCountries"
+												   value: "allCountries"
 					}
 				]
 			}
@@ -225,68 +229,63 @@ try {
 		let buffer = "";
 		let batch: string[] = [];
 		const ignoredCountries = new Set<string>();
-		const runLimited = limit(CONCURRENCY);
 
 		const flushBatch = async () => {
 			if (batch.length === 0) return;
 
 			const lines = batch;
 			batch = [];
+			const dataToInsert: any[] = [];
 
-			await Promise.all(
-				lines.map((line) =>
-					runLimited(async () => {
-						const trimmed = line.trim();
-						if (!trimmed) return;
+			for (const line of lines) {
+				const trimmed = line.trim();
+				if (!trimmed) continue;
 
-						const parts = trimmed.split("\t");
-						const id = parts[0];
-						const name = parts[1];
-						const latitude = parts[4];
-						const longitude = parts[5];
-						const countryCode = parts[8];
-						const population = parts[14];
+				const parts = trimmed.split("\t");
+				const id = parts[0];
+				const name = parts[1];
+				const latitude = parts[4];
+				const longitude = parts[5];
+				const countryCode = parts[8];
+				const population = parts[14];
 
-						if (!id || !name || !latitude || !longitude || !countryCode || !population) return;
+				if (!id || !name || !latitude || !longitude || !countryCode || !population) continue;
 
-						if (ignoredCountries.has(countryCode)) return;
+				if (ignoredCountries.has(countryCode)) continue;
 
-						const countryId = countryCodesToIDs.get(countryCode);
-						if (!countryId) {
-							ignoredCountries.add(countryCode);
-							console.warn(
-								chalk.yellow(`[${nowStr()}] Skipping unknown country:`),
-								countryCode
-							);
-							return;
-						}
+				const countryId = countryCodesToIDs.get(countryCode);
+				if (!countryId) {
+					ignoredCountries.add(countryCode);
+					console.warn(
+						chalk.yellow(`[${nowStr()}] Skipping unknown country:`),
+								 countryCode
+					);
+					continue;
+				}
 
-						const data = {
-							cityId: Number(id),
-							name,
-							number: 1,
-							countryId,
-							latitude: Number(latitude),
-							longitude: Number(longitude),
-							population: Number(population)
-						};
+				const parsedPopulation = population.trim() !== '' ? BigInt(population) : null;
 
-						try {
-							await prisma.region.upsert({
-								where: {
-									cityId: data.cityId
-								},
-								create: data,
-								update: data
-							});
-						} catch (error) {
-							if ((error as { code: string }).code !== "P2002") {
-								throw error;
-							}
-						}
-					})
-				)
-			);
+				dataToInsert.push({
+					cityId: Number(id),
+								  name,
+								  number: 1,
+								  countryId,
+								  latitude: Number(latitude),
+								  longitude: Number(longitude),
+								  population: parsedPopulation
+				});
+			}
+
+			if (dataToInsert.length > 0) {
+				try {
+					await prisma.region.createMany({
+						data: dataToInsert,
+						skipDuplicates: true
+					});
+				} catch (error) {
+					console.error("Batch insert failed:", error);
+				}
+			}
 
 			addedCount += lines.length;
 			process.stdout.write(

--- a/src/services/leaderboard.ts
+++ b/src/services/leaderboard.ts
@@ -50,10 +50,6 @@ export class LeaderboardService {
 					cleaned++;
 				}
 			}
-			// if (cleaned > 0) {
-			// 	const timestamp = new Date().toISOString();
-			// 	console.log(`[${timestamp}] Leaderboard cache cleanup: removed ${cleaned} expired entries`);
-			// }
 		}, 30_000);
 	}
 
@@ -99,32 +95,33 @@ export class LeaderboardService {
 				});
 			}
 
-			// Update or create entries
+			// Update or create entries using updateMany to bypass the read-modify-write race condition
 			for (const entry of entries) {
-				// Check if entry exists
-				const existing = await prisma.leaderboardView.findFirst({
+				const updateResult = await prisma.leaderboardView.updateMany({
 					where: {
 						type: entry.type,
 						mode: entry.mode,
 						entityId: entry.entityId
+					},
+					data: {
+						rank: entry.rank,
+						pixelsPainted: entry.pixelsPainted
 					}
 				});
 
-				// eslint-disable-next-line unicorn/prefer-ternary
-				if (existing) {
-					// Update existing entry
-					await prisma.leaderboardView.update({
-						where: { id: existing.id },
-						data: {
-							rank: entry.rank,
-							pixelsPainted: entry.pixelsPainted
+				// If count is 0, the entry does not exist yet
+				if (updateResult.count === 0) {
+					try {
+						await prisma.leaderboardView.create({
+							data: entry
+						});
+					} catch (error: any) {
+						// P2002 is Prisma's Unique Constraint error. 
+						// If another thread created it in the exact same millisecond, just ignore it safely.
+						if (error.code !== "P2002") {
+							throw error;
 						}
-					});
-				} else {
-					// Create new entry
-					await prisma.leaderboardView.create({
-						data: entry
-					});
+					}
 				}
 			}
 		});
@@ -135,14 +132,16 @@ export class LeaderboardService {
 			try {
 				return await operation();
 			} catch (error: any) {
-				// Check if it's a deadlock, write conflict, or timeout error
+				// Check if it's a deadlock, write conflict, timeout error, OR Error 1020
 				const isRetryableError = (
 					error.code === "P2034" ||
 					error.code === "P2024" ||
 					error.message?.includes("deadlock") ||
 					error.message?.includes("write conflict") ||
 					error.message?.includes("timeout") ||
-					error.message?.includes("connection")
+					error.message?.includes("connection") ||
+					error.message?.includes("1020") || // Added MySQL 1020 Catch
+					error.message?.includes("Record has changed since last read") // Added fallback
 				);
 
 				if (isRetryableError && attempt < maxRetries) {
@@ -710,8 +709,6 @@ export class LeaderboardService {
 				}
 			}
 
-			// console.log(`[${timestamp}] Leaderboard batch completed: ${batch.length} processed (queue: ${this.updateQueue.size})`);
-
 			if (this.updateQueue.size > 0) {
 				setTimeout(() => this.processUpdateQueue(), 500);
 			}
@@ -1093,9 +1090,6 @@ export class LeaderboardService {
 			});
 
 			await Promise.race([warmupPromise, timeoutPromise]);
-
-			// const duration = Date.now() - startTime;
-			// console.log(`[LeaderboardService] Warmup completed in ${duration}ms`);
 		} catch (error) {
 			const duration = Date.now() - startTime;
 			console.error(`[LeaderboardService] Warmup failed after ${duration}ms:`, error);
@@ -1140,4 +1134,3 @@ export class LeaderboardService {
 }
 
 export const leaderboardService = new LeaderboardService();
-

--- a/src/services/region.ts
+++ b/src/services/region.ts
@@ -25,133 +25,11 @@ export class RegionService {
 
 	private cache = new Map<string, Region>();
 	private inflight = new Map<string, Promise<Region>>();
-	private static indexLoaded = false;
-	private static indexLoadingPromise: Promise<void> | null = null;
-	private static binSizeDeg = 1;
-	private static bins = new Map<string, {
-		id: number;
-		cityId: number;
-		name: string;
-		number: number;
-		countryId: number;
-		latitude: number;
-		longitude: number
-	}[]>();
-	private static kd: { nearest: (pt: { latitude: number; longitude: number }) => Point | null } | null = null;
+
 	private staticKey(lat: number, lon: number): string {
 		const rLat = Math.round(lat * 10_000) / 10_000;
 		const rLon = Math.round(lon * 10_000) / 10_000;
 		return `${rLat}:${rLon}`;
-	}
-	private static binKey(lat: number, lon: number): string {
-		const s = RegionService.binSizeDeg;
-		const bLat = Math.floor(lat / s) * s;
-		const bLon = Math.floor(lon / s) * s;
-		return `${bLat}:${bLon}`;
-	}
-	private static neighbors(lat: number, lon: number, radiusBins: number): string[] {
-		const s = RegionService.binSizeDeg;
-		const bLat = Math.floor(lat / s);
-		const bLon = Math.floor(lon / s);
-		const keys: string[] = [];
-		for (let dy = -radiusBins; dy <= radiusBins; dy++) {
-			for (let dx = -radiusBins; dx <= radiusBins; dx++) {
-				keys.push(`${(bLat + dy) * s}:${(bLon + dx) * s}`);
-			}
-		}
-		return keys;
-	}
-	private static async ensureIndex(prisma: PrismaClient): Promise<void> {
-		if (RegionService.indexLoaded) return;
-		if (RegionService.indexLoadingPromise) {
-			await RegionService.indexLoadingPromise;
-			return;
-		}
-		RegionService.indexLoadingPromise = (async () => {
-			const rows = await prisma.region.findMany({
-				select: {
-					id: true,
-					cityId: true,
-					name: true,
-					number: true,
-					countryId: true,
-					latitude: true,
-					longitude: true
-				}
-			});
-			for (const r of rows) {
-				const key = RegionService.binKey(r.latitude as unknown as number, r.longitude as unknown as number);
-				if (!RegionService.bins.has(key)) RegionService.bins.set(key, []);
-				RegionService.bins.get(key)!.push({
-					id: r.id,
-					cityId: r.cityId,
-					name: r.name,
-					number: r.number,
-					countryId: r.countryId,
-					latitude: r.latitude as unknown as number,
-					longitude: r.longitude as unknown as number
-				});
-			}
-
-			// FORGIVE ME FATHER FOR I HAVE SINNED T.T
-			// Build a lightweight KD-Tree (2D) for fast nearest lookup (lazy version no lib)
-			// TODO: Lazy-calculate neighbors and cache to database instead of in-memory
-			const pts: Point[] = rows.map(r => ({
-				latitude: r.latitude as unknown as number,
-				longitude: r.longitude as unknown as number,
-				id: r.id,
-				cityId: r.cityId,
-				name: r.name,
-				number: r.number,
-				countryId: r.countryId
-			}));
-
-			interface Node { p: Point; axis: 0 | 1; left: Node | null; right: Node | null }
-
-			function build(points: Point[], depth: number): Node | null {
-				if (points.length === 0) return null;
-				const axis: 0 | 1 = (depth % 2) as 0 | 1;
-				points.sort((a, b) => (axis === 0 ? a.latitude - b.latitude : a.longitude - b.longitude));
-				const mid = Math.floor(points.length / 2);
-				const node: Node = {
-					p: points[mid] as Point,
-					axis,
-					left: build(points.slice(0, mid), depth + 1),
-					right: build(points.slice(mid + 1), depth + 1)
-				};
-				return node;
-			}
-			const root = build(pts, 0);
-			function sq(a: number) { return a * a }
-			function dist2(a: { latitude: number; longitude: number }, b: { latitude: number; longitude: number }) {
-				return sq(a.latitude - b.latitude) + sq(a.longitude - b.longitude);
-			}
-			function nearest(pt: { latitude: number; longitude: number }): Point | null {
-				let best: Point | null = null;
-				let bestD = Number.POSITIVE_INFINITY;
-				function search(node: Node | null) {
-					if (!node) return;
-					const np = node.p as Point;
-					const d = dist2(pt, np);
-					if (d < bestD) { bestD = d; best = np }
-					const axis = node.axis;
-					const delta = (axis === 0 ? pt.latitude - np.latitude : pt.longitude - np.longitude);
-					const first = delta < 0 ? node.left : node.right;
-					const second = delta < 0 ? node.right : node.left;
-					search(first);
-					if (delta * delta < bestD) search(second);
-				}
-				search(root);
-				return best;
-			}
-			RegionService.kd = { nearest: (pt) => nearest(pt) };
-
-			RegionService.indexLoaded = true;
-		})()
-			.finally(() => {
-				RegionService.indexLoadingPromise = null;
-			});
-		await RegionService.indexLoadingPromise;
 	}
 
 	static pixelsToCoordinates(tile: [number, number], pixel: [number, number], { tileSize, canonicalZ }: { tileSize?: number; canonicalZ?: number } = {}): { latitude: number; longitude: number } {
@@ -183,7 +61,6 @@ export class RegionService {
 		const work = (async () => {
 			const nearest = await this.findNearestRegionByDistance(latitude, longitude);
 			if (nearest) {
-				// console.log("nearest", nearest);
 				const result = {
 					id: nearest.id,
 					cityId: nearest.cityId,
@@ -197,6 +74,7 @@ export class RegionService {
 				return result;
 			}
 
+			// Fallback if no region found
 			return {
 				id: 0,
 				cityId: 0,
@@ -219,7 +97,7 @@ export class RegionService {
 	private deg2rad(v: number): number { return v * Math.PI / 180 }
 
 	// ref: https://stackoverflow.com/questions/27928/calculate-distance-between-two-latitude-longitude-points-haversine-formula
-	private getDistanceFromLatLon(a: { latitude: number; longitude: number }, b: { latitude: number; longitude: number }): number {
+	private getDistanceFromLatLon(a: { latitude: number; longitude: number }, b: { latitude: number; longitude: number }) {
 		const R = 6_371_000;
 		const dLat = this.deg2rad(b.latitude - a.latitude);
 		const dLon = this.deg2rad(b.longitude - a.longitude);
@@ -232,42 +110,41 @@ export class RegionService {
 	}
 
 	private async findNearestRegionByDistance(latitude: number, longitude: number) {
-		await RegionService.ensureIndex(this.prisma);
-		if (RegionService.kd) {
-			const p = RegionService.kd.nearest({ latitude, longitude });
-			if (p) return {
-				id: p.id,
-				cityId:
-				p.cityId,
-				name: p.name,
-				number: p.number,
-				countryId: p.countryId,
-				latitude: p.latitude,
-				longitude: p.longitude
-			};
-		}
-		let radius = 0;
-		for (let iter = 0; iter < 6; iter++) {
-			const keys = RegionService.neighbors(latitude, longitude, radius);
-			let best: { id: number; cityId: number; name: string; number: number; countryId: number; latitude: number; longitude: number } | null = null;
-			let bestD = Number.POSITIVE_INFINITY;
-			for (const k of keys) {
-				const bucket = RegionService.bins.get(k);
-				if (!bucket) continue;
-				for (const region of bucket) {
+		// Start with a small bounding box (~55km) to keep DB queries lightning fast
+		let radiusDeg = 0.5; 
+		const maxRadiusDeg = 5.0; // Max out at ~550km so we don't query the whole ocean
+
+		while (radiusDeg <= maxRadiusDeg) {
+			const minLat = latitude - radiusDeg;
+			const maxLat = latitude + radiusDeg;
+			const minLon = longitude - radiusDeg;
+			const maxLon = longitude + radiusDeg;
+
+			const candidates = await this.prisma.region.findMany({
+				where: {
+					latitude: { gte: minLat, lte: maxLat },
+					longitude: { gte: minLon, lte: maxLon }
+				}
+			});
+
+			if (candidates.length > 0) {
+				let best: any = null;
+				let bestD = Number.POSITIVE_INFINITY;
+				for (const region of candidates) {
 					const d = this.getDistanceFromLatLon(
-						{ latitude, longitude }, {
-							latitude: region.latitude,
-							longitude: region.longitude
-						});
+						{ latitude, longitude }, 
+						{ latitude: Number(region.latitude), longitude: Number(region.longitude) }
+					);
 					if (d < bestD) {
 						bestD = d;
 						best = region;
 					}
 				}
+				return best;
 			}
-			if (best) return best;
-			radius += 1;
+			
+			// If no cities found in the box, expand the search radius
+			radiusDeg *= 2; 
 		}
 		return null;
 	}
@@ -276,7 +153,7 @@ export class RegionService {
 		const queryLowercase = query.toLowerCase();
 		const results = await this.prisma.region.findMany({
 			where: {
-				name: { contains: queryLowercase }
+				name: { startsWith: queryLowercase } 
 			},
 			orderBy: {
 				population: "desc"
@@ -284,7 +161,6 @@ export class RegionService {
 			take: 20
 		});
 
-		// Sort by relevance: exact match -> population -> starts with -> name length
 		const sorted = results.sort((a, b) => {
 			const aName = a.name.toLowerCase();
 			const bName = b.name.toLowerCase();
@@ -301,19 +177,18 @@ export class RegionService {
 				return aStarts - bStarts;
 			}
 
-			const aPopulation = a.population ?? 0;
-			const bPopulation = b.population ?? 0;
-			if (aPopulation !== bPopulation) {
-				return bPopulation - aPopulation;
+			const popA = BigInt(a.population || 0);
+			const popB = BigInt(b.population || 0);
+			if (popA !== popB) {
+				return popB > popA ? 1 : -1;
 			}
 
 			return aName.length - bName.length;
-		})
-			.slice(0, 10);
+		}).slice(0, 10);
 
 		return sorted.map(item => ({
-			latitude: item.latitude,
-			longitude: item.longitude,
+			latitude: Number(item.latitude),
+			longitude: Number(item.longitude),
 			id: item.id,
 			cityId: item.cityId,
 			name: item.name,

--- a/src/services/region.ts
+++ b/src/services/region.ts
@@ -25,11 +25,133 @@ export class RegionService {
 
 	private cache = new Map<string, Region>();
 	private inflight = new Map<string, Promise<Region>>();
-
+	private static indexLoaded = false;
+	private static indexLoadingPromise: Promise<void> | null = null;
+	private static binSizeDeg = 1;
+	private static bins = new Map<string, {
+		id: number;
+		cityId: number;
+		name: string;
+		number: number;
+		countryId: number;
+		latitude: number;
+		longitude: number
+	}[]>();
+	private static kd: { nearest: (pt: { latitude: number; longitude: number }) => Point | null } | null = null;
 	private staticKey(lat: number, lon: number): string {
 		const rLat = Math.round(lat * 10_000) / 10_000;
 		const rLon = Math.round(lon * 10_000) / 10_000;
 		return `${rLat}:${rLon}`;
+	}
+	private static binKey(lat: number, lon: number): string {
+		const s = RegionService.binSizeDeg;
+		const bLat = Math.floor(lat / s) * s;
+		const bLon = Math.floor(lon / s) * s;
+		return `${bLat}:${bLon}`;
+	}
+	private static neighbors(lat: number, lon: number, radiusBins: number): string[] {
+		const s = RegionService.binSizeDeg;
+		const bLat = Math.floor(lat / s);
+		const bLon = Math.floor(lon / s);
+		const keys: string[] = [];
+		for (let dy = -radiusBins; dy <= radiusBins; dy++) {
+			for (let dx = -radiusBins; dx <= radiusBins; dx++) {
+				keys.push(`${(bLat + dy) * s}:${(bLon + dx) * s}`);
+			}
+		}
+		return keys;
+	}
+	private static async ensureIndex(prisma: PrismaClient): Promise<void> {
+		if (RegionService.indexLoaded) return;
+		if (RegionService.indexLoadingPromise) {
+			await RegionService.indexLoadingPromise;
+			return;
+		}
+		RegionService.indexLoadingPromise = (async () => {
+			const rows = await prisma.region.findMany({
+				select: {
+					id: true,
+					cityId: true,
+					name: true,
+					number: true,
+					countryId: true,
+					latitude: true,
+					longitude: true
+				}
+			});
+			for (const r of rows) {
+				const key = RegionService.binKey(r.latitude as unknown as number, r.longitude as unknown as number);
+				if (!RegionService.bins.has(key)) RegionService.bins.set(key, []);
+				RegionService.bins.get(key)!.push({
+					id: r.id,
+					cityId: r.cityId,
+					name: r.name,
+					number: r.number,
+					countryId: r.countryId,
+					latitude: r.latitude as unknown as number,
+					longitude: r.longitude as unknown as number
+				});
+			}
+
+			// FORGIVE ME FATHER FOR I HAVE SINNED T.T
+			// Build a lightweight KD-Tree (2D) for fast nearest lookup (lazy version no lib)
+			// TODO: Lazy-calculate neighbors and cache to database instead of in-memory
+			const pts: Point[] = rows.map(r => ({
+				latitude: r.latitude as unknown as number,
+				longitude: r.longitude as unknown as number,
+				id: r.id,
+				cityId: r.cityId,
+				name: r.name,
+				number: r.number,
+				countryId: r.countryId
+			}));
+
+			interface Node { p: Point; axis: 0 | 1; left: Node | null; right: Node | null }
+
+			function build(points: Point[], depth: number): Node | null {
+				if (points.length === 0) return null;
+				const axis: 0 | 1 = (depth % 2) as 0 | 1;
+				points.sort((a, b) => (axis === 0 ? a.latitude - b.latitude : a.longitude - b.longitude));
+				const mid = Math.floor(points.length / 2);
+				const node: Node = {
+					p: points[mid] as Point,
+					axis,
+					left: build(points.slice(0, mid), depth + 1),
+					right: build(points.slice(mid + 1), depth + 1)
+				};
+				return node;
+			}
+			const root = build(pts, 0);
+			function sq(a: number) { return a * a }
+			function dist2(a: { latitude: number; longitude: number }, b: { latitude: number; longitude: number }) {
+				return sq(a.latitude - b.latitude) + sq(a.longitude - b.longitude);
+			}
+			function nearest(pt: { latitude: number; longitude: number }): Point | null {
+				let best: Point | null = null;
+				let bestD = Number.POSITIVE_INFINITY;
+				function search(node: Node | null) {
+					if (!node) return;
+					const np = node.p as Point;
+					const d = dist2(pt, np);
+					if (d < bestD) { bestD = d; best = np }
+					const axis = node.axis;
+					const delta = (axis === 0 ? pt.latitude - np.latitude : pt.longitude - np.longitude);
+					const first = delta < 0 ? node.left : node.right;
+					const second = delta < 0 ? node.right : node.left;
+					search(first);
+					if (delta * delta < bestD) search(second);
+				}
+				search(root);
+				return best;
+			}
+			RegionService.kd = { nearest: (pt) => nearest(pt) };
+
+			RegionService.indexLoaded = true;
+		})()
+			.finally(() => {
+				RegionService.indexLoadingPromise = null;
+			});
+		await RegionService.indexLoadingPromise;
 	}
 
 	static pixelsToCoordinates(tile: [number, number], pixel: [number, number], { tileSize, canonicalZ }: { tileSize?: number; canonicalZ?: number } = {}): { latitude: number; longitude: number } {
@@ -61,6 +183,7 @@ export class RegionService {
 		const work = (async () => {
 			const nearest = await this.findNearestRegionByDistance(latitude, longitude);
 			if (nearest) {
+				// console.log("nearest", nearest);
 				const result = {
 					id: nearest.id,
 					cityId: nearest.cityId,
@@ -74,7 +197,6 @@ export class RegionService {
 				return result;
 			}
 
-			// Fallback if no region found
 			return {
 				id: 0,
 				cityId: 0,
@@ -97,7 +219,7 @@ export class RegionService {
 	private deg2rad(v: number): number { return v * Math.PI / 180 }
 
 	// ref: https://stackoverflow.com/questions/27928/calculate-distance-between-two-latitude-longitude-points-haversine-formula
-	private getDistanceFromLatLon(a: { latitude: number; longitude: number }, b: { latitude: number; longitude: number }) {
+	private getDistanceFromLatLon(a: { latitude: number; longitude: number }, b: { latitude: number; longitude: number }): number {
 		const R = 6_371_000;
 		const dLat = this.deg2rad(b.latitude - a.latitude);
 		const dLon = this.deg2rad(b.longitude - a.longitude);
@@ -110,41 +232,42 @@ export class RegionService {
 	}
 
 	private async findNearestRegionByDistance(latitude: number, longitude: number) {
-		// Start with a small bounding box (~55km) to keep DB queries lightning fast
-		let radiusDeg = 0.5; 
-		const maxRadiusDeg = 5.0; // Max out at ~550km so we don't query the whole ocean
-
-		while (radiusDeg <= maxRadiusDeg) {
-			const minLat = latitude - radiusDeg;
-			const maxLat = latitude + radiusDeg;
-			const minLon = longitude - radiusDeg;
-			const maxLon = longitude + radiusDeg;
-
-			const candidates = await this.prisma.region.findMany({
-				where: {
-					latitude: { gte: minLat, lte: maxLat },
-					longitude: { gte: minLon, lte: maxLon }
-				}
-			});
-
-			if (candidates.length > 0) {
-				let best: any = null;
-				let bestD = Number.POSITIVE_INFINITY;
-				for (const region of candidates) {
+		await RegionService.ensureIndex(this.prisma);
+		if (RegionService.kd) {
+			const p = RegionService.kd.nearest({ latitude, longitude });
+			if (p) return {
+				id: p.id,
+				cityId:
+				p.cityId,
+				name: p.name,
+				number: p.number,
+				countryId: p.countryId,
+				latitude: p.latitude,
+				longitude: p.longitude
+			};
+		}
+		let radius = 0;
+		for (let iter = 0; iter < 6; iter++) {
+			const keys = RegionService.neighbors(latitude, longitude, radius);
+			let best: { id: number; cityId: number; name: string; number: number; countryId: number; latitude: number; longitude: number } | null = null;
+			let bestD = Number.POSITIVE_INFINITY;
+			for (const k of keys) {
+				const bucket = RegionService.bins.get(k);
+				if (!bucket) continue;
+				for (const region of bucket) {
 					const d = this.getDistanceFromLatLon(
-						{ latitude, longitude }, 
-						{ latitude: Number(region.latitude), longitude: Number(region.longitude) }
-					);
+						{ latitude, longitude }, {
+							latitude: region.latitude,
+							longitude: region.longitude
+						});
 					if (d < bestD) {
 						bestD = d;
 						best = region;
 					}
 				}
-				return best;
 			}
-			
-			// If no cities found in the box, expand the search radius
-			radiusDeg *= 2; 
+			if (best) return best;
+			radius += 1;
 		}
 		return null;
 	}
@@ -153,7 +276,7 @@ export class RegionService {
 		const queryLowercase = query.toLowerCase();
 		const results = await this.prisma.region.findMany({
 			where: {
-				name: { startsWith: queryLowercase } 
+				name: { contains: queryLowercase }
 			},
 			orderBy: {
 				population: "desc"
@@ -161,6 +284,7 @@ export class RegionService {
 			take: 20
 		});
 
+		// Sort by relevance: exact match -> population -> starts with -> name length
 		const sorted = results.sort((a, b) => {
 			const aName = a.name.toLowerCase();
 			const bName = b.name.toLowerCase();
@@ -177,18 +301,19 @@ export class RegionService {
 				return aStarts - bStarts;
 			}
 
-			const popA = BigInt(a.population || 0);
-			const popB = BigInt(b.population || 0);
-			if (popA !== popB) {
-				return popB > popA ? 1 : -1;
+			const aPopulation = a.population ?? 0;
+			const bPopulation = b.population ?? 0;
+			if (aPopulation !== bPopulation) {
+				return bPopulation - aPopulation;
 			}
 
 			return aName.length - bName.length;
-		}).slice(0, 10);
+		})
+			.slice(0, 10);
 
 		return sorted.map(item => ({
-			latitude: Number(item.latitude),
-			longitude: Number(item.longitude),
+			latitude: item.latitude,
+			longitude: item.longitude,
 			id: item.id,
 			cityId: item.cityId,
 			name: item.name,


### PR DESCRIPTION
# changes
- Use BigInt instead of Int for large geonames like allCountries.txt, etc.....
- Optimize SQL import to make it much faster by using createMany batching instead
- Fix Error 1020 race condition

The reason I made this pull request was I accidentally used allcountries.txt, but hopefully this may fix some future issues